### PR TITLE
[#69915642] Bump vCloud Core version to 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.3 (2014-04-22)
+
+  Bugfixes:
+
+  - Requires vCloud Core v0.0.12 which fixes issue with progress bar falling over when progress is not returned
+
 ## 0.0.1 (2014-03-24)
 
   - First release of gem

--- a/lib/vcloud/net_launcher/version.rb
+++ b/lib/vcloud/net_launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module NetLauncher
-    VERSION = '0.0.1'
+    VERSION = '0.0.2'
   end
 end

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.11'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'cucumber', '~> 1.3.10'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
Bump vCloud Core to version 0.0.12, which fixes an issue where tasks
that would show a progress bar fall over which this error message:

```
undefined method `<' for nil:NilClass
```
