### PR TITLE
[#69915948] re-add documentation for rake default

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ If you want to be sure you are pinning to 5.1, or use 5.5, you can set the API v
 
 ## Testing
 
+Default target: `bundle exec rake` runs the cucumber features tests.
+
 `bundle exec rake integration` runs the integration tests.
 
 `bundle exec rake features` runs the cucumber features tests.


### PR DESCRIPTION
As per  https://github.com/alphagov/vcloud-net_launcher/pull/9/files comments, re-adding the documentation on the Rake default target -- albeit corrected to reflect the Rakefile behaviour (to run 'features').
