### PR TITLE
[#69995588] Move Vcloud::QueryRunner under Vcloud::Core 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Current (2014-04-30)
+
+  Features:
+
+  - Depend on version 0.1.0 of vcloud-core which introduces breaking changes to Vcloud::QueryRunner namespacing
+
 ## 0.0.2 (2014-04-22)
 
   Bugfixes:

--- a/spec/integration/net_launcher/vcloud_net_launcher_spec.rb
+++ b/spec/integration/net_launcher/vcloud_net_launcher_spec.rb
@@ -60,7 +60,7 @@ module Vcloud
       end
 
       def find_network(network_name)
-        query = Vcloud::QueryRunner.new()
+        query = Vcloud::Core::QueryRunner::.new()
         query.run('orgNetwork', :filter => "name==#{network_name}")
       end
 

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
+  s.add_runtime_dependency 'vcloud-core', '>= 0.1.0'
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'cucumber', '~> 1.3.10'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
Move Vcloud::QueryRunner under Vcloud::Core to comply with breaking
changes introduced in vcloud-core version 0.1.0.

Also bumps the dependency on vcloud-core in the Gemspec so that we use
version 0.1.0.

Note that I haven't bumped the version number for vcloud-net_launcher in this PR as there are further namespace changes we'd like to make (#70162466) before bumping the minor version.

Depends on https://github.com/alphagov/vcloud-core/pull/30.

---

Also fixes the version number of the most recent release in `CHANGELOG.md`.
