### PR TITLE
[#70500696] Use pessimistic version dependency for vcloud-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3 (2014-05-01)
+
+  - Use pessimistic version dependency for vcloud-core
+
 ## 0.0.2 (2014-04-22)
 
   Bugfixes:

--- a/lib/vcloud/net_launcher/version.rb
+++ b/lib/vcloud/net_launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module NetLauncher
-    VERSION = '0.0.2'
+    VERSION = '0.0.3'
   end
 end

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
 
   s.add_runtime_dependency 'methadone'
-  s.add_runtime_dependency 'vcloud-core', '>= 0.0.12'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.0.12'
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'cucumber', '~> 1.3.10'
   s.add_development_dependency 'gem_publisher', '1.2.0'


### PR DESCRIPTION
Use Ruby's pessimistic operator[1](http://guides.rubygems.org/patterns/#declaring_dependencies) for the version dependency on the
vcloud-core gem, which prevents us from installing a version of
vcloud-core with a greater minor version than the one specified.

In this case, only versions less than 0.1.0 will be installed.

This reinforces our policy of semantic versioning, whereby a minor
version bump may signify that changes in that versions are not backwards
compatible.

Also bump version to 0.0.3 to encourage people to download this version
in anticipation of breaking changes to come soon.
