### PR TITLE
[Prep work for #70443650] Fix broken integration tests

### DIFF
--- a/spec/integration/net_launcher/org_vdc_network_spec.rb
+++ b/spec/integration/net_launcher/org_vdc_network_spec.rb
@@ -56,17 +56,8 @@ describe Vcloud::Core::OrgVdcNetwork do
     end
 
     it 'should have an :ip_ranges list with each of our ranges' do
-      expect(@net.vcloud_attributes[:ip_ranges].size).to eq(@config[:ip_ranges].size)
-      expect(
-        @net.vcloud_attributes[:ip_ranges].detect do |ip_range|
-          ip_range == {:start_address=>"10.88.11.100", :end_address=>"10.88.11.150"}
-        end
-      ).to be_true
-      expect(
-        @net.vcloud_attributes[:ip_ranges].detect do |ip_range|
-          ip_range == {:start_address=>"10.88.11.200", :end_address=>"10.88.11.250"}
-        end
-      ).to be_true
+      expect(@net.vcloud_attributes[:ip_ranges]).
+       to match_array(@config[:ip_ranges])
     end
 
     after(:all) do
@@ -129,17 +120,8 @@ describe Vcloud::Core::OrgVdcNetwork do
     end
 
     it 'should have an :ip_ranges list with each of our ranges' do
-      expect(@net.vcloud_attributes[:ip_ranges].size).to eq(@config[:ip_ranges].size)
-      expect(
-        @net.vcloud_attributes[:ip_ranges].detect do |ip_range|
-          ip_range == {:start_address=>"10.88.11.100", :end_address=>"10.88.11.150"}
-        end
-      ).to be_true
-      expect(
-        @net.vcloud_attributes[:ip_ranges].detect do |ip_range|
-          ip_range == {:start_address=>"10.88.11.200", :end_address=>"10.88.11.250"}
-        end
-      ).to be_true
+      expect(@net.vcloud_attributes[:ip_ranges]).
+        to match_array(@config[:ip_ranges])
     end
 
     after(:all) do


### PR DESCRIPTION
During work on [#70443650] it was discovered that the integration tests were not functioning due to the 'expect(false) == true' bug seen elsewhere.

This PR fixes this up, and corrects the resulting failing tests.

When Vcloud::Core is updated to use get_network_complete (which will cause vcloud_attributes to return different data), these tests will need to be refreshed.
