### PR TITLE
Add Pry as a development dependency

### DIFF
--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'aruba', '~> 0.5.3'
   s.add_development_dependency 'cucumber', '~> 1.3.10'
   s.add_development_dependency 'gem_publisher', '1.2.0'
+  s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'
   s.add_development_dependency 'rubocop'


### PR DESCRIPTION
[Pry](http://pryrepl.org/) is a Ruby shell and is very useful for debugging.

You can use Pry by specifying `RUBYOPT='-r pry'` when running the vCloud Tools CLI commands and by adding breakpoints in your code, for example:

```
binding.pry
```

Hitting ^D will exit the shell and resume code execution after the break point.
