### PR TITLE
[#72432612] Rename Rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,6 @@ task :publish_gem do
 end
 
 require 'rubocop/rake_task'
-Rubocop::RakeTask.new(:rubocop) do |task|
+RuboCop::RakeTask.new(:rubocop) do |task|
   task.options = ['--lint']
 end

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 2.14.1'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 0.23.0'
 end
 


### PR DESCRIPTION
As of version 0.23.0[1](bbatsov/rubocop@7ee7a8b), Rubocop is now RuboCop. This broke our CI
builds.

Fix the namespacing in our Rakefile to reflect this and use pessimistic
versioning to pin Rubocop to the 0.23.x series in our gemspec file.
Since RuboCop's API is not yet stable (as would be the case from version
1.0.0), future changes such as these could break our builds again.
