### PR TITLE
[#67916012] Use new TestSetup interface to access test params

### DIFF
--- a/spec/integration/net_launcher/net_launch_spec.rb
+++ b/spec/integration/net_launcher/net_launch_spec.rb
@@ -50,7 +50,7 @@ module Vcloud
 
       def default_test_data(type)
         config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-        parameters = Vcloud::Tools::Tester::TestParameters.new(config_file)
+        parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
         {
           network_name: "vapp-vcloud-tools-tests-#{Time.now.strftime('%s')}",
           vdc_name: parameters.vdc_1_name,

--- a/spec/integration/net_launcher/org_vdc_network_spec.rb
+++ b/spec/integration/net_launcher/org_vdc_network_spec.rb
@@ -148,7 +148,7 @@ describe Vcloud::Core::OrgVdcNetwork do
 
   def define_test_data
     config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-    parameters = Vcloud::Tools::Tester::TestParameters.new(config_file)
+    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
     {
       :name => "orgVdcNetwork-vcloud-tools-tests #{Time.now.strftime('%s')}",
       :vdc_name => parameters.vdc_1_name,

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.3.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.5.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   # Pin SimpleCov to < 0.8.x until this issue is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '0.0.5'
+  s.add_development_dependency 'vcloud-tools-tester', '0.1.0'
 end
 


### PR DESCRIPTION
As of version 0.1.0 of the vCloud Tools Tester gem, we must use the
`Vcloud::Tools::Tester::TestSetup#test_params` method to retrieve test
parameters.

In doing so, that gem will ensure that the network fixtures are correct
in the vCloud organization that the integration tests run against.

Also, update the gemspec file to reflect this. We must now pin vCloud
Core to version 0.5.0, since vCloud Tools Tester also depends on that
version.

---

Note that I've intentionally left the `expected_user_params` argument
for `TestSetup#new` empty; this is new functionality that was added in
vCloud Tools Tester version 0.1.0 and is outside the scope of the
current story.
