### PR TITLE
[#72866380] Specify the required user-defined test params

### DIFF
--- a/spec/integration/net_launcher/net_launch_spec.rb
+++ b/spec/integration/net_launcher/net_launch_spec.rb
@@ -50,7 +50,9 @@ module Vcloud
 
       def default_test_data(type)
         config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-        parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+        required_user_params = %w{ vdc_1_name edge_gateway }
+
+        parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
         {
           network_name: "vapp-vcloud-tools-tests-#{Time.now.strftime('%s')}",
           vdc_name: parameters.vdc_1_name,

--- a/spec/integration/net_launcher/org_vdc_network_spec.rb
+++ b/spec/integration/net_launcher/org_vdc_network_spec.rb
@@ -148,7 +148,9 @@ describe Vcloud::Core::OrgVdcNetwork do
 
   def define_test_data
     config_file = File.join(File.dirname(__FILE__), "../vcloud_tools_testing_config.yaml")
-    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, []).test_params
+    required_user_params = %w{ vdc_1_name edge_gateway }
+
+    parameters = Vcloud::Tools::Tester::TestSetup.new(config_file, required_user_params).test_params
     {
       :name => "orgVdcNetwork-vcloud-tools-tests #{Time.now.strftime('%s')}",
       :vdc_name => parameters.vdc_1_name,


### PR DESCRIPTION
By specifying the user-defined test parameters we require for each test,
vCloud Tools Tester will fail fast if these parameters are not defined.
