### PR TITLE
[#73962736] Document public methods with Rdoc

### DIFF
--- a/lib/vcloud/net_launcher/cli.rb
+++ b/lib/vcloud/net_launcher/cli.rb
@@ -4,8 +4,10 @@ module Vcloud
   module NetLauncher
     class Cli
 
-      # Returns an instance of +Cli+, which handles parsing of command-line
-      # arguments and acts as an entry point for the main application logic.
+      # Initiates parsing of the command-line arguments.
+      #
+      # @param  argv_array [Array] Command-line arguments
+      # @return [void]
       def initialize(argv_array)
         @usage_text = nil
         @config_file = nil
@@ -18,6 +20,8 @@ module Vcloud
 
       # Runs +Vcloud::NetLauncher::NetLaunch#run+ to create networks defined
       # in +@config_file+, catching any exceptions to prevent printing a backtrace.
+      #
+      # @return [void]
       def run
         begin
           Vcloud::NetLauncher::NetLaunch.new.run(@config_file, @options)

--- a/lib/vcloud/net_launcher/net_launch.rb
+++ b/lib/vcloud/net_launcher/net_launch.rb
@@ -4,11 +4,18 @@ module Vcloud
   module NetLauncher
     class NetLaunch
 
+      # Initializes instance variables.
+      #
+      # @return [void]
       def initialize
         @config_loader = Vcloud::Core::ConfigLoader.new
       end
 
       # Parses a configuration file and provisions the networks it defines.
+      #
+      # @param  config_file [String]  Path to a YAML or JSON-formatted configuration file
+      # @param  options     [Hash]    Runtime options
+      # @return [void]
       def run(config_file = nil, options = {})
         config = @config_loader.load_config(config_file, Vcloud::NetLauncher::Schema::NET_LAUNCH)
 


### PR DESCRIPTION
Document the public API methods using Rdoc.

Note I have not documented `NetLaunch#new` as there was nothing I could
add that would not repeat the documentation for `NetLaunch#run` and I
think it's simple enough so as to be self-explanatory.

Also, YARD (though not Rdoc) will automatically document it as:

> A new instance of NetLaunch.

---

For discussion; please let me know if this is too simplistic.
