### PR TITLE
[#66147100] remove the cli option for mocking

### DIFF
--- a/lib/vcloud/net_launcher/cli.rb
+++ b/lib/vcloud/net_launcher/cli.rb
@@ -11,9 +11,6 @@ module Vcloud
       def initialize(argv_array)
         @usage_text = nil
         @config_file = nil
-        @options = {
-          "mock" => false,
-        }
 
         parse(argv_array)
       end
@@ -24,7 +21,7 @@ module Vcloud
       # @return [void]
       def run
         begin
-          Vcloud::NetLauncher::NetLaunch.new.run(@config_file, @options)
+          Vcloud::NetLauncher::NetLaunch.new.run(@config_file)
         rescue => error_msg
           $stderr.puts(error_msg)
           exit 1
@@ -59,10 +56,6 @@ Example configuration files can be found in:
 
           opts.separator ""
           opts.separator "Options:"
-
-          opts.on("-m", "--mock", "Fog Mock mode enabled") do
-            @options["mock"] = true
-          end
 
           opts.on("-h", "--help", "Print usage and exit") do
             $stderr.puts opts

--- a/lib/vcloud/net_launcher/net_launch.rb
+++ b/lib/vcloud/net_launcher/net_launch.rb
@@ -14,14 +14,9 @@ module Vcloud
       # Parses a configuration file and provisions the networks it defines.
       #
       # @param  config_file [String]  Path to a YAML or JSON-formatted configuration file
-      # @param  options     [Hash]    Runtime options
       # @return [void]
-      def run(config_file = nil, options = {})
+      def run(config_file = nil)
         config = @config_loader.load_config(config_file, Vcloud::NetLauncher::Schema::NET_LAUNCH)
-
-        if options[:mock] || ENV['FOG_MOCK']
-          ::Fog.mock!
-        end
 
         config[:org_vdc_networks].each do |net_config|
           net_config[:fence_mode] ||= 'isolated'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,3 +31,11 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 end
+
+# To enable Fog Mock mode use FOG_CREDENTIAL=fog_mock and FOG_MOCK=true
+# If you do not have configuration for fog_mock in your vcloud_tools_testing_config.yaml,
+# the test data is defined here: https://github.com/fog/fog/blob/master/lib/fog/vcloud_director/compute.rb#L483-L733
+#
+if ENV['FOG_MOCK']
+  Fog.mock!
+end

--- a/spec/vcloud/net_launcher/cli_spec.rb
+++ b/spec/vcloud/net_launcher/cli_spec.rb
@@ -40,29 +40,13 @@ describe Vcloud::NetLauncher::Cli do
         expect(Vcloud::NetLauncher::NetLaunch).to receive(:new).
           and_return(mock_net_launch)
         expect(mock_net_launch).to receive(:run).
-          with(config_file, cli_options)
+          with(config_file)
         expect(subject.exitstatus).to eq(0)
       end
     end
 
     context "when given a single config file" do
       let(:args) { [ config_file ] }
-      let(:cli_options) {
-        {
-          "mock" => false,
-        }
-      }
-
-      it_behaves_like "a good CLI command"
-    end
-
-    context "when asked to use mock mode" do
-      let(:args) { [ config_file, "--mock" ] }
-      let(:cli_options) {
-        {
-          "mock" => true,
-        }
-      }
 
       it_behaves_like "a good CLI command"
     end

--- a/spec/vcloud/net_launcher/net_launch_spec.rb
+++ b/spec/vcloud/net_launcher/net_launch_spec.rb
@@ -48,7 +48,7 @@ describe Vcloud::NetLauncher::NetLaunch do
       expect(Vcloud::Core::OrgVdcNetwork).to receive(:provision).with(network2)
       expect(Vcloud::Core::OrgVdcNetwork).to receive(:provision).with(network3)
 
-      subject.run('input_config_yaml', cli_options)
+      subject.run('input_config_yaml')
     end
 
     it "should abort on errors from Vcloud::Core" do
@@ -58,25 +58,8 @@ describe Vcloud::NetLauncher::NetLaunch do
       expect(Vcloud::Core::OrgVdcNetwork).not_to receive(:provision).with(network3)
 
       expect {
-        Vcloud::NetLauncher::NetLaunch.new.run('input_config_yaml', cli_options)
+        Vcloud::NetLauncher::NetLaunch.new.run('input_config_yaml')
       }.to raise_error(RuntimeError, 'Did not successfully create orgVdcNetwork')
-    end
-
-    describe "fog mocking" do
-      it "should not mock fog by default" do
-        expect(Fog).to_not receive(:mock!)
-        expect(Vcloud::Core::OrgVdcNetwork).to receive(:provision).exactly(3).times
-
-        subject.run('input_config_yaml', cli_options)
-      end
-
-      it "should mock fog when passed option" do
-        expect(Fog).to receive(:mock!)
-        expect(Vcloud::Core::OrgVdcNetwork).to receive(:provision).exactly(3).times
-
-        cli_options = { :mock => true }
-        subject.run('input_config_yaml', cli_options)
-      end
     end
 
   end
@@ -108,7 +91,7 @@ describe Vcloud::NetLauncher::NetLaunch do
       expect(network_without_fence_mode).not_to have_key(:fence_mode)
       expect(Vcloud::Core::OrgVdcNetwork).to receive(:provision).with(network_with_fence_mode)
 
-      subject.run('input_config_yaml', cli_options)
+      subject.run('input_config_yaml')
     end
   end
 end


### PR DESCRIPTION
Remove the cli option to enable fog mocking. None of other tools have one and 
people use and environment variable to use it anyway.

Also move the enabling of fog mocking via an environment variable to the
spec_helper instead of in the class.
