### PR TITLE
Bump versions to save trouble later

### DIFF
--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.9.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.10.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'
@@ -31,6 +31,6 @@ Gem::Specification.new do |s|
   # Pin SimpleCov to < 0.8.x until this issue is resolved:
   # https://github.com/colszowka/simplecov/issues/281
   s.add_development_dependency 'simplecov', '~> 0.7.1'
-  s.add_development_dependency 'vcloud-tools-tester', '~> 0.1.0'
+  s.add_development_dependency 'vcloud-tools-tester', '~> 0.2.0'
 end
 


### PR DESCRIPTION
vCloud Core 0.10.0 requires the project using it to have at least vCloud Tools Tester 0.2.0 because of a circular dependency. Bumping this now to avoid issues later.
