### PR TITLE
Add missing schema definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## CURRENT
+
+  - Fix schema bug preventing use of 'description', 'is_shared', 'dns_suffix' options
+
 ## 0.5.1 (2014-08-12)
 
   - Upgrade dependency on vCloud Core to 0.10.0 for parity with other vCloud

--- a/lib/vcloud/net_launcher/schema/net_launch.rb
+++ b/lib/vcloud/net_launcher/schema/net_launch.rb
@@ -15,6 +15,10 @@ module Vcloud
                   type: 'string',
                   required: true,
                 },
+                description: {
+                  type: 'string',
+                  required: false,
+                },
                 edge_gateway: {
                   type: 'string',
                   required: false,
@@ -27,6 +31,10 @@ module Vcloud
                   type: 'enum',
                   required: false,
                   acceptable_values: %w{ isolated natRouted },
+                },
+                is_shared: {
+                  type: 'boolean',
+                  required: false,
                 },
                 is_inherited: {
                   type: 'boolean',
@@ -42,6 +50,10 @@ module Vcloud
                 },
                 netmask: {
                   type: 'ip_address',
+                  required: false,
+                },
+                dns_suffix: {
+                  type: 'string',
                   required: false,
                 },
                 dns1: {

--- a/spec/vcloud/net_launcher/net_launch_schema_spec.rb
+++ b/spec/vcloud/net_launcher/net_launch_schema_spec.rb
@@ -2,12 +2,33 @@ require 'spec_helper'
 
 describe Vcloud::NetLauncher do
   context "NetLaunch schema validation" do
-    it "validates a legal schema" do
+    it "validates a legal minimal schema" do
       test_config = {
         :org_vdc_networks => [
           :name     =>  "Valid network",
           :vdc_name =>  "Some vDC"
         ]
+      }
+
+      validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::NetLauncher::Schema::NET_LAUNCH)
+      expect(validator.valid?).to be_true
+      expect(validator.errors).to be_empty
+    end
+
+    it "validates a legal more complete schema" do
+      test_config = {
+        :org_vdc_networks => [ {
+          :name        =>  "Valid network",
+          :description => "A description of this network",
+          :vdc_name    =>  "Some vDC",
+          :fence_mode  =>  "isolated",
+          :is_shared   =>  true,
+          :gateway     =>  "192.0.2.1",
+          :netmask     =>  "255.255.255.0",
+          :dns_suffix  =>  "mynet.example.com",
+          :dns1        =>  "192.0.2.11",
+          :dns2        =>  "192.0.2.12",
+        }]
       }
 
       validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::NetLauncher::Schema::NET_LAUNCH)


### PR DESCRIPTION
Vcloud::Core::OrgVdcNetwork.provision handles :description, :is_shared,
and :dns_suffix options. These were omitted from the net_launch schema however,
so vcloud-net_launch would fail if they were specified.

Added them in as optional parameters, and extended the tests accordingly.
