### PR TITLE
Bump vcloud-core dep to 0.11.0 and release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## CURRENT
+## 0.6.0 (2014-09-11)
 
   - Fix schema bug preventing use of 'description', 'is_shared', 'dns_suffix' options
+  - Upgrade dependency on vCloud Core to 0.11.0 which prevents plaintext
+    passwords in FOG_RC. Please use tokens via vcloud-login as per
+    the documentation: http://gds-operations.github.io/vcloud-tools/usage/
 
 ## 0.5.1 (2014-08-12)
 

--- a/lib/vcloud/net_launcher/version.rb
+++ b/lib/vcloud/net_launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module NetLauncher
-    VERSION = '0.5.1'
+    VERSION = '0.6.0'
   end
 end

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 0.10.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 0.11.0'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Changes:
- plaintext passwords are no longer permissible in FOG_RC
  See http://gds-operations.github.io/vcloud-tools/usage/
