### PR TITLE
Allow anchors to be created under a dedicated key

### DIFF
--- a/lib/vcloud/net_launcher/schema/net_launch.rb
+++ b/lib/vcloud/net_launcher/schema/net_launch.rb
@@ -5,6 +5,10 @@ module Vcloud
       NET_LAUNCH = {
         type: 'hash',
         internals: {
+          anchors: {
+            type: 'hash',
+            required: false,
+          },
           org_vdc_networks: {
             type: 'array',
             required: true,

--- a/spec/vcloud/net_launcher/net_launch_schema_spec.rb
+++ b/spec/vcloud/net_launcher/net_launch_schema_spec.rb
@@ -48,6 +48,21 @@ describe Vcloud::NetLauncher do
       expect(validator.errors).to eq(["base: parameter 'no_networks_here' is invalid", "base: missing 'org_vdc_networks' parameter"])
     end
 
+    it "allows anchors" do
+      test_config = {
+        :anchors => {
+          foo: :bar,
+        },
+        :org_vdc_networks => [
+          :name       =>  "Valid network",
+          :vdc_name   =>  "Some vDC",
+        ]
+      }
+      validator = Vcloud::Core::ConfigValidator.validate(:base, test_config, Vcloud::NetLauncher::Schema::NET_LAUNCH)
+      expect(validator.valid?).to be_true
+      expect(validator.errors).to be_empty
+    end
+
     it "allows multiple IP ranges" do
       test_config = {
         :org_vdc_networks => [


### PR DESCRIPTION

It is sometimes useful to extract common config into YAML anchors. Currently
the config schema is very strict, and fails if any additional keys are present
in the config file. This change would allow an open-ended `anchors` key to
exist in the config file, under which any number of anchors can be created.

##### Example

```
---
anchors:
  common: &common
    edge_gateway: "nft0000000"
    vdc_name: "my-vdc"
    fence_mode: 'natRouted'
    netmask: '255.255.255.0'

org_vdc_networks:
  - name: 'app'
    description: 'app network'
    gateway: '10.0.0.1'
    ip_ranges:
      - start_address: '10.0.0.2'
      - end_address: '10.0.0.254'
    <<: *common
```

Just after making this patch I noticed [this spec][0] which hints that using
anchors is kinda expected, so hopefully this isn't too weird. I think it would
be useful across the tools. I'm happy to create PRs for the other tools if we
agree it should be added.

[0]: https://github.com/gds-operations/vcloud-core/blob/master/spec/vcloud/core/config_loader_spec.rb#L24
