### PR TITLE
Remove support for Ruby version 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.2
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+  - Remove support for Ruby 1.9.3, which is now end-of-life.
+
 ## 1.0.1 (2015-07-22)
 
   - Bump vCloud Core to 1.1.0 to allow releasing `vcloud-tools`.

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,4 +2,6 @@
 set -e
 
 ./jenkins_tests.sh
+
+source ./rbenv_version.sh
 bundle exec rake publish_gem

--- a/jenkins_tests.sh
+++ b/jenkins_tests.sh
@@ -18,6 +18,8 @@ ${FOG_CREDENTIAL}:
   vcloud_director_password: ''
 EOF
 
+source ./rbenv_version.sh
+
 git clean -ffdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake

--- a/rbenv_version.sh
+++ b/rbenv_version.sh
@@ -1,0 +1,1 @@
+export RBENV_VERSION="2.0.0"


### PR DESCRIPTION
Ruby 1.9.3 is end-of-life as of February 2015, and we have removed
support for it from vcloud-core:
gds-operations/vcloud-core@1a26f58

* * *

Also, explicitly set the rbenv version to 2.0.0, the oldest version we
support, in both `jenkins.sh` and `jenkins_tests.sh`.

Run the tests using the oldest version so as to increase the likelihood
that we'll catch changes that break backwards compatibility.

Use a `rbenv_version.sh` file to avoid duplicating the version number.
I've avoided using `.ruby-version` file, which is supported by rbenv, to
avoid the implication that the version mentioned in `.ruby-version` is
the only one supported by the project.