### PR TITLE
Bump vcloud-core and release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Unreleased
+## 2.0.0 (2015-10-20)
 
   - Remove support for Ruby 1.9.3, which is now end-of-life.
+  - Allow anchors to be created under a dedicated key
+  - Relax dependency on vCloud Core to make it easier to install alongside
+    other vCloud gems.
 
 ## 1.0.1 (2015-07-22)
 

--- a/lib/vcloud/net_launcher/version.rb
+++ b/lib/vcloud/net_launcher/version.rb
@@ -1,5 +1,5 @@
 module Vcloud
   module NetLauncher
-    VERSION = '1.0.1'
+    VERSION = '2.0.0'
   end
 end

--- a/vcloud-net_launcher.gemspec
+++ b/vcloud-net_launcher.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'vcloud-core', '~> 1.1.0'
+  s.add_runtime_dependency 'vcloud-core', '~> 1.1'
   s.add_development_dependency 'gem_publisher', '1.2.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
In order to make it easier to install this gem alongside the other
vCloud gems, we should relax the dependency on vcloud-core so that
bundler can resolve dependencies.